### PR TITLE
OutfitDefs

### DIFF
--- a/DLL_Project/CommunityCoreLibrary.csproj
+++ b/DLL_Project/CommunityCoreLibrary.csproj
@@ -59,9 +59,11 @@
   <ItemGroup>
     <Compile Include="Classes\InputField.cs" />
     <Compile Include="Classes\Static\CCL_Widgets.cs" />
+    <Compile Include="Defs\OutfitDef.cs" />
     <Compile Include="Defs\BackstoryDef.cs" />
     <Compile Include="Defs\NameDef.cs" />
     <Compile Include="Defs\PawnBioDef.cs" />
+    <Compile Include="Detours\OutfitDatabase.cs" />
     <Compile Include="Extensions\BackstoryDefExt.cs" />
     <Compile Include="Extensions\BiomeDef_Extensions.cs" />
     <Compile Include="Extensions\DesignationCategoryDef_Extensions.cs" />

--- a/DLL_Project/Defs/OutfitDef.cs
+++ b/DLL_Project/Defs/OutfitDef.cs
@@ -1,0 +1,28 @@
+﻿using Verse;
+using CommunityCoreLibrary.Detour;
+
+namespace CommunityCoreLibrary
+{
+
+    public class OutfitDef : Def
+    {
+        #region XML Data
+
+        public string                               label               = "";
+        public ThingFilter                          filter              = new ThingFilter();
+
+        #endregion
+
+        public static OutfitDef Named(string defName)
+        {
+            return DefDatabase<OutfitDef>.GetNamed(defName);
+        }
+
+        public override void ResolveReferences()
+        {
+            base.ResolveReferences();
+
+            _OutfitDatabase.OutfitDefs.Add(this);
+        }
+    }
+}

--- a/DLL_Project/Detours/OutfitDatabase.cs
+++ b/DLL_Project/Detours/OutfitDatabase.cs
@@ -1,0 +1,55 @@
+﻿using RimWorld;
+using System.Collections.Generic;
+using Verse;
+
+namespace CommunityCoreLibrary.Detour
+{
+    internal static class _OutfitDatabase
+    {
+        public static List<OutfitDef> OutfitDefs = new List<OutfitDef>();
+
+        internal static void _GenerateStartingOutfits(this OutfitDatabase outfitDatabase)
+        {
+            outfitDatabase.MakeNewOutfit().label = "Anything";
+
+            Outfit outfit = outfitDatabase.MakeNewOutfit();
+            outfit.label = "Nothing";
+            outfit.filter.SetDisallowAll();
+
+            Outfit outfit1 = outfitDatabase.MakeNewOutfit();
+            outfit1.label = "Worker";
+            outfit1.filter.SetDisallowAll();
+            foreach (ThingDef allDef in DefDatabase<ThingDef>.AllDefs)
+            {
+                if (allDef.apparel != null && allDef.apparel.defaultOutfitTags != null && allDef.apparel.defaultOutfitTags.Contains("Worker"))
+                    outfit1.filter.SetAllow(allDef, true);
+            }
+
+            Outfit outfit2 = outfitDatabase.MakeNewOutfit();
+            outfit2.label = "Soldier";
+            outfit2.filter.SetDisallowAll();
+            foreach (ThingDef allDef in DefDatabase<ThingDef>.AllDefs)
+            {
+                if (allDef.apparel != null && allDef.apparel.defaultOutfitTags != null && allDef.apparel.defaultOutfitTags.Contains("Soldier"))
+                    outfit2.filter.SetAllow(allDef, true);
+            }
+
+            Outfit outfit3 = outfitDatabase.MakeNewOutfit();
+            outfit3.label = "Nudist";
+            outfit3.filter.SetDisallowAll();
+            foreach (ThingDef allDef in DefDatabase<ThingDef>.AllDefs)
+            {
+                if (allDef.apparel != null && !allDef.apparel.bodyPartGroups.Contains(BodyPartGroupDefOf.Legs) && !allDef.apparel.bodyPartGroups.Contains(BodyPartGroupDefOf.Torso))
+                    outfit3.filter.SetAllow(allDef, true);
+            }
+
+            // do my stuff here
+            foreach (OutfitDef outfitDef in OutfitDefs)
+            {
+                Outfit newOutfit = outfitDatabase.MakeNewOutfit();
+                newOutfit.label = outfitDef.label;
+                newOutfit.filter = outfitDef.filter;
+            }
+        }
+    }
+}

--- a/DLL_Project/SpecialInjectors/DetourInjector.cs
+++ b/DLL_Project/SpecialInjectors/DetourInjector.cs
@@ -223,6 +223,12 @@ namespace CommunityCoreLibrary
             if( !Detours.TryDetourFromTo( Verse_ModLister_InstalledModsListHash, CCL_ModLister_InstalledModsListHash ) )
                 return false;
 
+            // Detour RimWorld.OutfitDatabase.GenerateStartingOutfits
+            MethodInfo RimWorld_OutfitDatabase_GenerateStartingOutfits = typeof(OutfitDatabase).GetMethod("GenerateStartingOutfits", BindingFlags.Instance | BindingFlags.NonPublic);
+            MethodInfo CCL_OutfitDatabase_GenerateStartingOutfits = typeof(Detour._OutfitDatabase).GetMethod("_GenerateStartingOutfits", BindingFlags.Static | BindingFlags.NonPublic);
+            if (!Detours.TryDetourFromTo(RimWorld_OutfitDatabase_GenerateStartingOutfits, CCL_OutfitDatabase_GenerateStartingOutfits))
+                return false;
+
             /*
             // Detour 
             MethodInfo foo = typeof( foo_class ).GetMethod( "foo_method", BindingFlags.Static | BindingFlags.NonPublic );

--- a/_Mod/Modders Resource/Def Descriptions/OutfitDefs/OutfitDef.xml
+++ b/_Mod/Modders Resource/Def Descriptions/OutfitDefs/OutfitDef.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <!--
+  <CommunityCoreLibrary.OutfitDef>
+
+    <defName>string</defName>                 [required] Assign the outfit a defName. Make sure this is unique! A good way of making sure it is unique is by adding a prefix, such as the first three letters of your username.
+
+    <label>string</label>                     [required] This is the long version of the title. Make sure to only capitalise the first word and no others, otherwise you will get an error.
+
+    <filter>                                  [required] This is the actual filter for what this outfit allows/disallows
+
+      <disallowedSpecialFilters>              [optional] Things to disallow such as corpses and rotten stuff
+        <li></li>
+      </disallowedSpecialFilters>
+
+      <allowedDefs>                           [optional] This is the items you want to allow for the outfit.
+        <li></li>
+      </allowedDefs>
+
+      <allowedHitPointsPercents>numeric range</allowedHitPointsPercents> [required] Hit point range to allow. For default outfits '0~1' is used.
+      <allowedQualityLevels>quality range</allowedQualityLevels> [required] Quality level range to allow. For default outfits 'Awful~Legendary' is used.
+    </filter>
+
+  </CommunityCoreLibrary.OutfitDef>
+  -->
+
+  <!-- disallowed special filters:
+  AllowCorpsesColonist
+  AllowCorpsesStranger
+  AllowRotten
+  AllowNonSmeltableWeapons
+  -->
+
+  <!-- allowed:
+  values for this can vary based on installed mods, refer a save file with the outfit you want for specific values
+  -->
+
+  <!-- allowed hit point percentages:
+  this is a range with ~ between the numbers ('0~1' is the default to allow all)
+  -->
+
+  <!-- allowed quality levels:
+  this is a range of quality levels range can be between any of the following (first is lowest, last is highest, 'Awful~Legendary' is default to allow all)
+  Awful
+  Shoddy
+  Poor
+  Normal
+  Good
+  Superior
+  Excellent
+  Masterwork
+  Legendary
+  -->
+</Defs>

--- a/_Mod/Modders Resource/Examples/Outfits/OutfitDef Example/About/About.xml
+++ b/_Mod/Modders Resource/Examples/Outfits/OutfitDef Example/About/About.xml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ModMetaData>
+    <name>OutfitDef Example</name>
+    <author>RimWorld CCL Team</author>
+    <url>n/a</url>
+    <targetVersion>0.14.1238</targetVersion>
+    <description>
+This is an example of how to add your own default outfits.
+
+Demonstrates:
+	CommunityCoreLibrary.OutfitDef Facilities
+    </description>
+</ModMetaData>

--- a/_Mod/Modders Resource/Examples/Outfits/OutfitDef Example/Defs/OutfitDefs/OutfitDef.xml
+++ b/_Mod/Modders Resource/Examples/Outfits/OutfitDef Example/Defs/OutfitDefs/OutfitDef.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <CommunityCoreLibrary.OutfitDef>
+    <defName>TrueNudist</defName>
+    <label>True Nudist</label>
+    <filter>
+      <disallowedSpecialFilters>
+        <li>AllowCorpsesColonist</li>
+        <li>AllowCorpsesStranger</li>
+        <li>AllowRotten</li>
+        <li>AllowNonSmeltableWeapons</li>
+      </disallowedSpecialFilters>
+      <allowedDefs />
+      <allowedHitPointsPercents>0~1</allowedHitPointsPercents>
+      <allowedQualities>Awful~Legendary</allowedQualities>
+    </filter>
+  </CommunityCoreLibrary.OutfitDef>
+
+  <CommunityCoreLibrary.OutfitDef>
+    <defName>Cowboy</defName>
+    <label>Cowboy</label>
+    <filter>
+      <disallowedSpecialFilters>
+        <li>AllowCorpsesColonist</li>
+        <li>AllowCorpsesStranger</li>
+        <li>AllowRotten</li>
+        <li>AllowNonSmeltableWeapons</li>
+      </disallowedSpecialFilters>
+      <allowedDefs>
+        <li>Apparel_BasicShirt</li>
+        <li>Apparel_CowboyHat</li>
+        <li>Apparel_Duster</li>
+        <li>Apparel_Pants</li>
+      </allowedDefs>
+      <allowedHitPointsPercents>0~1</allowedHitPointsPercents>
+      <allowedQualities>Awful~Legendary</allowedQualities>
+    </filter>
+  </CommunityCoreLibrary.OutfitDef>
+
+</Defs>

--- a/_Mod/Modders Resource/Examples/Outfits/OutfitDef Example/Defs/OutfitDefs/OutfitDef.xml
+++ b/_Mod/Modders Resource/Examples/Outfits/OutfitDef Example/Defs/OutfitDefs/OutfitDef.xml
@@ -2,22 +2,6 @@
 <Defs>
 
   <CommunityCoreLibrary.OutfitDef>
-    <defName>TrueNudist</defName>
-    <label>True Nudist</label>
-    <filter>
-      <disallowedSpecialFilters>
-        <li>AllowCorpsesColonist</li>
-        <li>AllowCorpsesStranger</li>
-        <li>AllowRotten</li>
-        <li>AllowNonSmeltableWeapons</li>
-      </disallowedSpecialFilters>
-      <allowedDefs />
-      <allowedHitPointsPercents>0~1</allowedHitPointsPercents>
-      <allowedQualities>Awful~Legendary</allowedQualities>
-    </filter>
-  </CommunityCoreLibrary.OutfitDef>
-
-  <CommunityCoreLibrary.OutfitDef>
     <defName>Cowboy</defName>
     <label>Cowboy</label>
     <filter>


### PR DESCRIPTION
```
- adds ability to use OutfitDef to create new default outfits to start
games with
- also adds the 'Nothing' outfit which is the opposite of 'Anything'
```

Since the outfit database isn't static (which is why you can't reuse outfits from one game to another) I made it so modders can now define their own outfits that get loaded when a new game calls new OutfitDatabase() and GenerateStartingOutfits() is triggered. I used a detour to do this and put all it's previous code (just the 3 outfits, Anything, Worker, Soldier, Nudist) into this function, plus added a 'Nothing' outfit (mainly because Nudist still let you wear stuff), and after those are setup then it loops through the outfit defs that were saved to CommunityCoreLibrary.Detour._OutfitDatabase.OutfitDefs and creates their outfits as well.

Let me know if there are any coding style or changes needed to get this merged in. I think it'd be a good addition to allow modders that are adding custom apparel to be able to also define custom outfits.
