### PR TITLE
Fixed Learn to play translation error.

### DIFF
--- a/_Mod/Modders Resource/Community Core Library/Defs/MainMenuDefs/MainMenus.xml
+++ b/_Mod/Modders Resource/Community Core Library/Defs/MainMenuDefs/MainMenus.xml
@@ -3,7 +3,7 @@
 
     <CommunityCoreLibrary.MainMenuDef>
         <defName>LearnToPlay</defName>
-        <labelKey>LearnToPlay</labelKey>
+        <labelKey>Tutorial</labelKey>
         <order>800</order>
         <menuClass>CommunityCoreLibrary.MainMenu_LearnToPlay</menuClass>
         <!--


### PR DESCRIPTION
 The text showed garbled with no spaces in my game.

It looks like A15 uses "Tutorial" as the translate key, not "LearnToPlay"
Changed LabelKey in the learn to play menu entry's def file to "Tutorial."

From the decompiled code.
        string label = "Tutorial".CanTranslate() ? "Tutorial".Translate() : "LearnToPlay".Translate();
        optList.Add(new ListableOption(label, (Action) (() => MainMenuDrawer.InitLearnToPlay()), (string) null));
        optList.Add(new ListableOption("NewColony".Translate(), (Action) (() => Find.WindowStack.Add((Window) new Page_SelectScenario())), (string) null));
