### PR TITLE
Fixed Learn to play translation error

### DIFF
--- a/DLL_Project/Detours/MainMenuDrawer.cs
+++ b/DLL_Project/Detours/MainMenuDrawer.cs
@@ -169,6 +169,11 @@ namespace CommunityCoreLibrary.Detour
 
             foreach( var menu in currentMainMenuDefs )
             {
+                if (menu.labelKey == "LearnToPlay" && "Tutorial".CanTranslate())
+                {
+                    CCL_Log.Message("Found LTP button.");
+                    menu.labelKey = "Tutorial";
+                }
                 mainOptions.Add( new ListableOption_MainMenu( menu ) );
             }
 

--- a/DLL_Project/Detours/MainMenuDrawer.cs
+++ b/DLL_Project/Detours/MainMenuDrawer.cs
@@ -171,7 +171,6 @@ namespace CommunityCoreLibrary.Detour
             {
                 if (menu.labelKey == "LearnToPlay" && "Tutorial".CanTranslate())
                 {
-                    CCL_Log.Message("Found LTP button.");
                     menu.labelKey = "Tutorial";
                 }
                 mainOptions.Add( new ListableOption_MainMenu( menu ) );

--- a/_Mod/Modders Resource/Community Core Library/Defs/MainMenuDefs/MainMenus.xml
+++ b/_Mod/Modders Resource/Community Core Library/Defs/MainMenuDefs/MainMenus.xml
@@ -3,7 +3,7 @@
 
     <CommunityCoreLibrary.MainMenuDef>
         <defName>LearnToPlay</defName>
-        <labelKey>LearnToPlay</labelKey>
+        <labelKey>Tutorial</labelKey>
         <order>800</order>
         <menuClass>CommunityCoreLibrary.MainMenu_LearnToPlay</menuClass>
         <!--

--- a/_Mod/Modders Resource/Community Core Library/Defs/MainMenuDefs/MainMenus.xml
+++ b/_Mod/Modders Resource/Community Core Library/Defs/MainMenuDefs/MainMenus.xml
@@ -3,7 +3,7 @@
 
     <CommunityCoreLibrary.MainMenuDef>
         <defName>LearnToPlay</defName>
-        <labelKey>Tutorial</labelKey>
+        <labelKey>LearnToPlay</labelKey>
         <order>800</order>
         <menuClass>CommunityCoreLibrary.MainMenu_LearnToPlay</menuClass>
         <!--


### PR DESCRIPTION
The text showed a garbled "LearnToPlay" for the tutorial button.
It looks like A15 uses "Tutorial" as the English translate key, not "LearnToPlay".
However, it still uses "LearnToPlay" for other languages.

French XML from my Core/Languages/French/Keyed/Menus_Main.xml

``` xml
<LearnToPlay>Apprendre à jouer</LearnToPlay>
```

English XML from my Core/Languages/English/Keyed/Menus_Main.xml

``` xml
<Tutorial>Tutorial</Tutorial>
```

Looks like base game fixes it with this: (Decompiled Code)
        string label = "Tutorial".CanTranslate() ? "Tutorial".Translate() : "LearnToPlay".Translate();
        optList.Add(new ListableOption(label, (Action) (() => MainMenuDrawer.InitLearnToPlay()), (string) null));
        optList.Add(new ListableOption("NewColony".Translate(), (Action) (() => Find.WindowStack.Add((Window) new Page_SelectScenario())), (string) null));

So, I added code to find the menu item, test if "Tutorial" is translatable, and change it to "Tutorial" before it gets passed to the CCL menu drawer.
