### PR TITLE
Working on Issue #179. 

### DIFF
--- a/DLL_Project/Detours/JoyGiver_SocialRelax.cs
+++ b/DLL_Project/Detours/JoyGiver_SocialRelax.cs
@@ -125,13 +125,26 @@ namespace CommunityCoreLibrary.Detour
                             false ),
                         40f,
                         (drug) =>
-                    {
-                        if( ingester.CanReserve( drug, 1 ) )
                         {
-                            return !drug.IsForbidden( ingester );
-                        }
-                        return false;
-                    },
+                            if( drug.IsForbidden( ingester ) )
+                            {
+                                return false;
+                            }
+
+                            if( drug is Building_AutomatedFactory )
+                            {
+                                var FS = drug as Building_AutomatedFactory;
+                                if(
+                                    ( !FS.InteractionCell.Standable() ) ||
+                                    ( !FS.CompPowerTrader.PowerOn ) ||
+                                    ( FS.BestProduct( FoodSynthesis.IsDrug, FoodSynthesis.SortDrug ) == null )
+                                )
+                                {
+                                    return false;
+                                }
+                            }
+                            return ingester.CanReserve( drug, 1 );
+                        },
                         null );
                     if( ingestible != null )
                     {
@@ -218,46 +231,12 @@ namespace CommunityCoreLibrary.Detour
                         )
                     )
                     {
-                        List<Thing> list = Find.ListerThings.AllThings.Where( t => (
-                            ( t.def.IsDrug ) ||
-                            ( t is Building_AutomatedFactory )
-                        ) ).ToList();
-                        if( list.Count > 0 )
+                        Thing thing;
+                        if( TryFindIngestibleToNurse(compGatherSpot.parent.Position, pawn, out thing)
+                                && thing != null)
                         {
-                            Thing thing = GenClosest.ClosestThing_Global_Reachable(
-                                compGatherSpot.parent.Position,
-                                list,
-                                PathEndMode.OnCell,
-                                TraverseParms.For(
-                                    pawn,
-                                    pawn.NormalMaxDanger() ),
-                                40f,
-                                ( t ) =>
-                            {
-                                if( t.IsForbidden( pawn ) )
-                                {
-                                    return false;
-                                }
-
-                                if( t is Building_AutomatedFactory )
-                                {
-                                    var FS = t as Building_AutomatedFactory;
-                                    if(
-                                        ( !FS.InteractionCell.Standable() ) ||
-                                        ( !FS.CompPowerTrader.PowerOn ) ||
-                                        ( FS.BestProduct( FoodSynthesis.IsDrug, FoodSynthesis.SortDrug ) == null )
-                                    )
-                                    {
-                                        return false;
-                                    }
-                                }
-                                return pawn.CanReserve( t, 1 );
-                            } );
-                            if( thing != null )
-                            {
-                                job.targetC = (TargetInfo)thing;
-                                job.maxNumToCarry = Mathf.Min( thing.stackCount, thing.def.ingestible.maxNumToIngestAtOnce );
-                            }
+                            job.targetC = (TargetInfo)thing;
+                            job.maxNumToCarry = Mathf.Min( thing.stackCount, thing.def.ingestible.maxNumToIngestAtOnce );
                         }
                     }
                     return job;


### PR DESCRIPTION
Fixed issue where pawns would social relax with any drug.

Moved the ClosetThing_Global_Reachable predicate in TryGiveJobInt to TryFindIngestibleToNurse.
Additional work required to use automated factories. I'm not sure how to implement that. Left the factory checks in the predicate for now.

TryFindIngestibleToNurse was already detoured and followed drug policy, but the method was never called in the Detoured TryGiveJobInt method.
Instead the TryGiveJobInt method just found all drugs and passed them to the ClosetThing_Global_Reachable.

Not sure how to enable the automated factories, so I'll leave that to the maintainer.
